### PR TITLE
Add lock orientation actions.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.BIND_ACCESSIBILITY_SERVICE"/>
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY"/>
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"/>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/wangrunz/bixbyremap/MainActivity.java
+++ b/app/src/main/java/wangrunz/bixbyremap/MainActivity.java
@@ -44,6 +44,7 @@ import android.widget.CompoundButton;
 import android.widget.SeekBar;
 import android.widget.Switch;
 import android.widget.TextView;
+import android.net.Uri;
 
 import org.w3c.dom.Text;
 
@@ -282,7 +283,8 @@ public class MainActivity extends AppCompatActivity {
         device_menu.add(R.id.menu_device_action,107,Menu.NONE,"Flash");
         device_menu.add(R.id.menu_device_action,108,Menu.NONE,"Ringer Mode");
         device_menu.add(R.id.menu_device_action,109,Menu.NONE,"Voice Assistance");
-
+        device_menu.add(R.id.menu_device_action,110,Menu.NONE,"Lock in Portrait");
+        device_menu.add(R.id.menu_device_action,111,Menu.NONE,"Lock in Landscape");
 
         SubMenu media_menu = menu.getItem(1).getSubMenu();
 
@@ -310,6 +312,11 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
                 SharedPreferences.Editor edit = sharedPreferences.edit();
+
+                if (item.getItemId()==110 || item.getItemId()==111) {
+                  requestSettingsPermission();
+                }
+
                 if (item.getItemId()<100){
                     return false;
                 }
@@ -350,6 +357,14 @@ public class MainActivity extends AppCompatActivity {
         });
 
         popupMenu.show();
+    }
+
+    void requestSettingsPermission() {
+      if (!Settings.System.canWrite(this)) {
+        startActivity(new Intent(
+                Settings.ACTION_MANAGE_WRITE_SETTINGS,
+                Uri.parse("package:" + getPackageName())));
+      }
     }
 
     void runUpdatesIfNecessary() {

--- a/app/src/main/java/wangrunz/bixbyremap/MyAccessibilityService.java
+++ b/app/src/main/java/wangrunz/bixbyremap/MyAccessibilityService.java
@@ -34,9 +34,11 @@ import android.hardware.camera2.CameraManager;
 import android.media.AudioManager;
 import android.os.Handler;
 import android.os.Vibrator;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.KeyEvent;
+import android.view.Surface;
 import android.view.accessibility.AccessibilityEvent;
 import android.widget.Toast;
 
@@ -190,6 +192,12 @@ public class MyAccessibilityService extends AccessibilityService {
                 case "Voice Assistance":
                     startActivity(new Intent(Intent.ACTION_VOICE_COMMAND).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK));
                     break;
+                case "Lock in Portrait":
+                    toggleOrientation(Surface.ROTATION_0);
+                    break;
+                case "Lock in Landscape":
+                    toggleOrientation(Surface.ROTATION_90);
+                    break;
             }
             return true;
         }
@@ -202,6 +210,19 @@ public class MyAccessibilityService extends AccessibilityService {
         else {
             return false;
         }
+    }
+
+    private void toggleOrientation(int wantedRotation) {
+      boolean auto = Settings.System.getInt(getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 0) != 0;
+      int current = Settings.System.getInt(getContentResolver(), Settings.System.USER_ROTATION, 0);
+      Log.d(getClass().getName(), String.format("toggleOrientation auto=%b preferred=%d wanted=%d",
+              auto, current, wantedRotation));
+      if (!auto && current == wantedRotation) {
+        Settings.System.putInt(getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 1);
+      } else {
+        Settings.System.putInt(getContentResolver(), Settings.System.ACCELEROMETER_ROTATION, 0);
+        Settings.System.putInt(getContentResolver(), Settings.System.USER_ROTATION, wantedRotation);
+      }
     }
 
     private boolean mediaControl(String targetName) {


### PR DESCRIPTION
These actions actually toggle orientation between being locked in the desired rotation and accelerometer-controlled.

This also requires WRITE_SETTINGS permission to write to Settings.System.